### PR TITLE
Fixes for proxy_validation

### DIFF
--- a/app/controllers/cassy/sessions_controller.rb
+++ b/app/controllers/cassy/sessions_controller.rb
@@ -130,7 +130,7 @@ module Cassy
       @service_ticket, @error = Cassy::ServiceTicket.validate(@service, @ticket)
       @extra_attributes = {}
       if @service_ticket
-        @username = ticketed_user(t)[settings[:cas_app_user_filed]]
+        @username = ticketed_user(@service_ticket)[settings[:client_app_user_field]]
 
         if @service_ticket.kind_of? Cassy::ProxyTicket
           @proxies << t.granted_by_pgt.service_ticket.service


### PR DESCRIPTION
The proxy_validation code is fubar, and assumed to be untested. Use the correct variable for the service ticket, and the correct config value for the app_user_field.
