### PR TITLE
Test proxyValidate as per serviceValidate, fix bugs in proxyValidate

### DIFF
--- a/app/controllers/cassy/sessions_controller.rb
+++ b/app/controllers/cassy/sessions_controller.rb
@@ -130,7 +130,7 @@ module Cassy
       @service_ticket, @error = Cassy::ServiceTicket.validate(@service, @ticket)
       @extra_attributes = {}
       if @service_ticket
-        @username = ticketed_user(@service_ticket)[settings[:client_app_user_field]]
+        @username = ticketed_user(@service_ticket).send(settings[:client_app_user_field])
 
         if @service_ticket.kind_of? Cassy::ProxyTicket
           @proxies << t.granted_by_pgt.service_ticket.service

--- a/spec/authenticators/test_spec.rb
+++ b/spec/authenticators/test_spec.rb
@@ -134,7 +134,7 @@ describe Cassy::Authenticators::Test do
 
   end # describe '/logout'
 
-  describe "proxyValidate" do
+  describe "serviceValidate" do
     before do
 
       visit "/cas/login?service="+CGI.escape(@target_service)
@@ -155,4 +155,27 @@ describe Cassy::Authenticators::Test do
       page.body.should match("<full_name>Example User</full_name>")
     end
   end
+
+  describe "proxyValidate" do
+    before do
+
+      visit "/cas/login?service="+CGI.escape(@target_service)
+
+      fill_in 'username', :with => VALID_USERNAME
+      fill_in 'Password', :with => VALID_PASSWORD
+
+      click_button 'Login'
+
+      page.current_url.should =~ /^#{Regexp.escape(@target_service)}\/?\?ticket=ST\-[1-9rA-Z]+/
+      @ticket = page.current_url.match(/ticket=(.*)$/)[1]
+    end
+
+    it "should have extra attributes in proper format" do
+      Cassy::Engine.config.configuration[:extra_attributes] = [{ :user => :full_name }]
+      visit "/cas/proxyValidate?service=#{CGI.escape(@target_service)}&ticket=#{@ticket}"
+      
+      page.body.should match("<full_name>Example User</full_name>")
+    end
+  end
+
 end


### PR DESCRIPTION
- Rename proxyValidate test to serviceValidate, since that's what it tests
- Copy the serviceValidate test for a first cut of a proxyValidate test
- Fix the method used to read the username in  SessionsController#proxy_validate
