### PR TITLE
Don't require yaml for configuration

### DIFF
--- a/lib/cassy/engine.rb
+++ b/lib/cassy/engine.rb
@@ -1,8 +1,10 @@
 module Cassy
   class Engine < Rails::Engine
     config.config_file = ENV["RUBYCAS_CONFIG_FILE"]
-    config.after_initialize do 
-      config.configuration = HashWithIndifferentAccess.new(YAML.load_file(config.config_file))
+    config.after_initialize do
+      if config.config_file && File.exists?(config.config_file)
+        config.configuration = HashWithIndifferentAccess.new(YAML.load_file(config.config_file))
+      end
     end
   end
 end


### PR DESCRIPTION
This addresses the issues raised in issue #5.

For our deployment, we must have Cassy config options that are different for each instance running, but which are deterministic based on some easily grabbed config settings on the box. This makes using a yaml file impractical. This pull request allows you to set the configuration in Ruby code, such as in a Rails initializer:

``` ruby
config = ActiveSupport::HashWithIndifferentAccess.new({
  maximum_unused_login_ticket_lifetime: 300,
  maximum_unused_service_ticket_lifetime: 300,
  username_field: 'login',
  client_app_user_field: 'username',
  authenticator: {'class' => 'Cassy::Authenticators::MyApp'},
  service_list: {
    production: ["http://#{my_service_domain}/cas_security_check"],
    development: [
      'http://localhost:8081/cas_security_check',
      'http://localhost:3000/cas_security_check'
    ]
  },
  default_redirect_url: {
    development: 'http://localhost:3000',
    production: "http://#{my_service_domain}"
  },
  loosely_match_services: true
})

Cassy::Engine.config.configuration = config
```
