### PR TITLE
Don't look for user by ticket without ticket

### DIFF
--- a/lib/cassy/authenticators/devise.rb
+++ b/lib/cassy/authenticators/devise.rb
@@ -9,6 +9,7 @@ module Cassy
       end
 
       def self.find_user_from_ticket(ticket)
+        return if ticket.nil?
         key  = Cassy.config[:client_app_user_field] || Cassy.config[:username_field] || "email"
         method = "find_by_#{key}"
         User.send(method, ticket.username)


### PR DESCRIPTION
It seems to me that at present Cas#valid_credentials?, when using the Devise authenticator, will raise an error for all login failures. The issue is that if a user lookup by credentials fails, #valid_credentials? will fall back to trying to find the user by ticket, even if tgt is nil. The Devise authenticator tries to call #username on tgt, which will raise a NoMethodError error if tgt is nil, which, as far as I can tell, is always the case in the event of a login failure.

My suggested fix is simple: short circuit if tgt is nil.

It's possible that this is an issue related to how I have Cassy configured at the moment, but from what I can tell that doesn't seem to be the case.

I've tried to include relevant code chunks below for easy reference.

Cas#valid_credentials?

```
def valid_credentials?
  detect_ticketing_service(params[:service])
  @extra_attributes = {}
  # Should probably be moved out of the request cycle and into an after init hook on the engine

  credentials = { :username => @username,
                  :password => @password,
                  :service  => @service,
                  :request  => @env
                }
  @user = authenticator.find_user(credentials) || authenticator.find_user_from_ticket(@tgt)
  valid = ((@user == @ticketed_user) || authenticator.validate(credentials)) && !!@user
  if valid && @user
    authenticator.extra_attributes_to_extract.each do |attr|
      @extra_attributes[attr] = @user.send(attr)
    end
  end
  return valid
end
```

Cassy::Authenticators::Devise::find_user_from_ticket

```
def self.find_user_from_ticket(ticket)
  key  = Cassy.config[:client_app_user_field] || Cassy.config[:username_field] || "email"
  method = "find_by_#{key}"
  User.send(method, ticket.username)
end
```
