### PR TITLE
Verify a user is valid_for_authentication? during Devise validation

### DIFF
--- a/lib/cassy/authenticators/devise.rb
+++ b/lib/cassy/authenticators/devise.rb
@@ -17,7 +17,7 @@ module Cassy
       def self.validate(credentials)
         user = find_user(credentials)
         # Did we find a user, are they active? and is their password valid?
-        user && user.active_for_authentication? && user.valid_password?(credentials[:password])
+        user && user.active_for_authentication? && user.valid_for_authentication? { user.valid_password?(credentials[:password]) }
       end
     end
   end


### PR DESCRIPTION
Adds a call to user.valid_for_authentication? to verify that the user is valid for authentication during the Devise validate method.

This change provides support for the lockable Devise model. If valid_for_authentication? is not called, the failed_attempts count and locking hooks are not invoked.

valid_for_authentication? takes a block that is expected to return a boolean indicating where or not the user is valid for authentication. As such I've moved the password verification into the block.
