### PR TITLE
Authenticator should receive the request as its :request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 if ENV.key?('RAILS_VERSION')
     railsversion = "= #{ENV['RAILS_VERSION']}"
 else
-    railsversion = ['>= 3.1.10']
+    railsversion = ['5.2.4']
 end
 
 gem 'rails', railsversion

--- a/app/controllers/cassy/sessions_controller.rb
+++ b/app/controllers/cassy/sessions_controller.rb
@@ -77,10 +77,9 @@ module Cassy
       
       if tgt
         Cassy::TicketGrantingTicket.transaction do
-          pgts = Cassy::ProxyGrantingTicket.find(:all,
-            :conditions => [ActiveRecord::Base.connection.quote_table_name(Cassy::ServiceTicket.table_name)+".username = ?", tgt.username],
-            :include => :service_ticket)
-          pgts.each do |pgt|
+          pgts = Cassy::ProxyGrantingTicket.where(Cassy::ServiceTicket.table_name => { :username => tgt.username }).
+            includes(:service_ticket)
+          pgts.find_each do |pgt|
             pgt.destroy
           end
           if Cassy.config[:enable_single_sign_out]

--- a/app/models/cassy/login_ticket.rb
+++ b/app/models/cassy/login_ticket.rb
@@ -3,9 +3,9 @@ module Cassy
   	include Cassy::Ticket
     self.table_name = 'casserver_lt'
     include Consumable
-    
-    def self.validate(ticket="invalid")
-      ticket = LoginTicket.find_by_ticket(ticket)
+
+    def self.validate_ticket(ticket="invalid")
+      ticket = LoginTicket.find_by(ticket: ticket)
       if ticket
         if ticket.consumed?
           {:valid => false, :error => "The login ticket you provided has already been used up. Please try logging in again."}
@@ -18,6 +18,6 @@ module Cassy
         {:valid => false, :error => "The login ticket you provided is invalid. There may be a problem with the authentication system."}
       end
     end
-        
+
   end
 end

--- a/app/models/cassy/proxy_granting_ticket.rb
+++ b/app/models/cassy/proxy_granting_ticket.rb
@@ -7,12 +7,12 @@ module Cassy
       :class_name => 'Cassy::ProxyTicket',
       :foreign_key => :granted_by_pgt_id
   end
-  
-  def self.validate(ticket)
+
+  def self.validate_ticket(ticket)
     if ticket.nil?
       error = Error.new(:INVALID_REQUEST, "pgt parameter was missing in the request.")
       logger.warn("#{error.code} - #{error.message}")
-    elsif pgt = ProxyGrantingTicket.find_by_ticket(ticket)
+    elsif pgt = ProxyGrantingTicket.find_by(ticket: ticket)
       if pgt.service_ticket
         logger.info("Proxy granting ticket '#{ticket}' belonging to user '#{pgt.service_ticket.username}' successfully validated.")
       else
@@ -26,5 +26,5 @@ module Cassy
 
     [pgt, error]
   end
-  
+
 end

--- a/app/models/cassy/proxy_ticket.rb
+++ b/app/models/cassy/proxy_ticket.rb
@@ -4,9 +4,9 @@ module Cassy
       :class_name => 'Cassy::ProxyGrantingTicket',
       :foreign_key => :granted_by_pgt_id
   end
-  
-  def validate(service, ticket)
-    pt, error = Cassy::ServiceTicket.validate(service, ticket, true)
+
+  def validate_ticket(service, ticket)
+    pt, error = Cassy::ServiceTicket.validate_ticket(service, ticket, true)
 
     if pt.kind_of?(Cassy::ProxyTicket) && !error
       if not pt.granted_by_pgt
@@ -19,5 +19,5 @@ module Cassy
 
     [pt, error]
   end
-  
+
 end

--- a/app/models/cassy/service_ticket.rb
+++ b/app/models/cassy/service_ticket.rb
@@ -19,14 +19,14 @@ module Cassy
 
     belongs_to :granted_by_tgt, :class_name => 'Cassy::TicketGrantingTicket', :foreign_key => :granted_by_tgt_id
     has_one :proxy_granting_ticket, :foreign_key => :created_by_st_id
-    
-    def self.validate(service, ticket, allow_proxy_tickets = false)
+
+    def self.validate_ticket(service, ticket, allow_proxy_tickets = false)
       logger.debug "Validating service ticket '#{ticket}' for service '#{service}'"
 
       if service.nil?
         logger.warn "Service not provided to validate service ticket"
         [nil, "Ticket or service parameter was missing in the request"]
-      elsif st = Cassy::ServiceTicket.find_by_ticket(ticket)
+      elsif st = Cassy::ServiceTicket.find_by(ticket: ticket)
         if st.consumed?
           logger.warn "Ticket #{ticket} has already been used"
           [nil, "Ticket #{ticket} has already been consumed."]
@@ -49,7 +49,7 @@ module Cassy
         [nil, "Ticket '#{ticket}' not recognized."]
       end
     end
-    
+
 
     def matches_service?(service)
       if Cassy.config[:loosely_match_services] == true
@@ -58,7 +58,7 @@ module Cassy
         Cassy::CAS.clean_service_url(self.service) == Cassy::CAS.clean_service_url(service)
       end
     end
-    
+
     # Takes an existing ServiceTicket object (presumably pulled from the database)
     # and sends a POST with logout information to the service that the ticket
     # was generated for.
@@ -89,20 +89,20 @@ module Cassy
         return false
       end
     end
-    
+
     # XML to be posted when using single sign out
     def logout_notification_message
       time = Time.now
       rand = Cassy::Utils.random_string
       {'logoutRequest' => %{<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="#{rand}" Version="2.0" IssueInstant="#{time.rfc2822}"><saml:NameID></saml:NameID><samlp:SessionIndex>#{self.ticket}</samlp:SessionIndex></samlp:LogoutRequest>}}
     end
-    
+
     # Try to find an existing service ticket for the given user and service
     def self.find_or_generate(service, username, tgt, hostname)
       st = tgt.granted_service_tickets.where(:service => service).where("created_on > ?", Time.now - Cassy.config[:maximum_session_lifetime]).order("created_on DESC").first
       st || self.generate(service, username, tgt, hostname)
     end
-    
+
     def self.generate(service, username, tgt, hostname)
       st = ServiceTicket.new
       st.ticket = "ST-" + Cassy::Utils.random_string
@@ -115,6 +115,6 @@ module Cassy
         " for user '#{st.username}' at '#{st.client_hostname}'")
       st
     end
-    
+
   end
 end

--- a/cassy.gemspec
+++ b/cassy.gemspec
@@ -11,11 +11,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'crypt-isaac'
   s.add_dependency 'rails', '>= 3.0.9'
 
-  s.add_development_dependency 'rspec-rails', '~> 2.7.0'
-  s.add_development_dependency 'capybara', '~> 1.0'
+  s.add_development_dependency 'rspec-rails', '~> 3.9.0'
+  s.add_development_dependency 'capybara', '~> 2.2.0'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'launchy'
-  s.add_development_dependency 'devise', '~> 3.2.4'
+  s.add_development_dependency 'devise', '~> 4.7.1'
   s.add_development_dependency 'webmock'
 end

--- a/lib/cassy.rb
+++ b/lib/cassy.rb
@@ -3,20 +3,20 @@ require 'cassy/routes'
 
 module Cassy
   extend ActiveSupport::Autoload
-  
+
   autoload :CAS
   autoload :Utils
   autoload :Engine
-  
+
   def self.root
     Pathname.new(File.dirname(__FILE__) + "../..")
   end
-  
+
   # Just an easier way to get to the configuration for the engine
   def self.config
     Cassy::Engine.config.configuration
   end
-  
+
   class AuthenticatorError < Exception
   end
 end

--- a/lib/cassy/cas.rb
+++ b/lib/cassy/cas.rb
@@ -201,7 +201,7 @@ module Cassy
       credentials = { :username => @username,
                       :password => @password,
                       :service  => @service,
-                      :request  => @env
+                      :request  => request
                     }
       @user = authenticator.find_user(credentials) || authenticator.find_user_from_ticket(@tgt)
       valid = ((@user == @ticketed_user) || authenticator.validate(credentials)) && !!@user

--- a/lib/cassy/engine.rb
+++ b/lib/cassy/engine.rb
@@ -1,8 +1,8 @@
 module Cassy
   class Engine < Rails::Engine
     config.config_file = ENV["RUBYCAS_CONFIG_FILE"]
-    config.after_initialize do 
-      config.configuration = HashWithIndifferentAccess.new(YAML.load_file(config.config_file))
+    config.after_initialize do
+      config.configuration = ActiveSupport::HashWithIndifferentAccess.new(YAML.load_file(config.config_file))
     end
   end
 end

--- a/lib/cassy/utils.rb
+++ b/lib/cassy/utils.rb
@@ -1,4 +1,4 @@
-require 'crypt-isaac'
+require 'crypt/isaac'
 
 # Misc utility function used throughout by the RubyCAS-Server.
 module Cassy

--- a/spec/models/login_ticket_spec.rb
+++ b/spec/models/login_ticket_spec.rb
@@ -6,24 +6,24 @@ describe Cassy::LoginTicket do
     Cassy::LoginTicket.delete_all
     @login_ticket = Cassy::LoginTicket.create(:ticket => "ST-12345678901234567890", :consumed => false, :client_hostname => "http://sso.something.com")
   end
-  
+
   it "should validate" do
-    Cassy::LoginTicket.validate("ST-12345678901234567890").should == {:valid => true}    
+    Cassy::LoginTicket.validate_ticket("ST-12345678901234567890").should == {:valid => true}
   end
-  
+
   it "should not validate if the ticket has already been consumed" do
     @login_ticket.consume!
-    Cassy::LoginTicket.validate("ST-12345678901234567890").should == {:valid => false, :error => "The login ticket you provided has already been used up. Please try logging in again."}
+    Cassy::LoginTicket.validate_ticket("ST-12345678901234567890").should == {:valid => false, :error => "The login ticket you provided has already been used up. Please try logging in again."}
   end
 
   it "should not validate if the ticket is too old" do
     @login_ticket.created_on = Time.now-7201
     @login_ticket.save!
-    Cassy::LoginTicket.validate("ST-12345678901234567890").should == {:valid => false, :error => "You took too long to enter your credentials. Please try again."}
+    Cassy::LoginTicket.validate_ticket("ST-12345678901234567890").should == {:valid => false, :error => "You took too long to enter your credentials. Please try again."}
   end
-  
+
   it "should not validate if the ticket is invalid" do
-    Cassy::LoginTicket.validate("ST-09876543210987654321").should == {:valid => false, :error => "The login ticket you provided is invalid. There may be a problem with the authentication system."}
+    Cassy::LoginTicket.validate_ticket("ST-09876543210987654321").should == {:valid => false, :error => "The login ticket you provided is invalid. There may be a problem with the authentication system."}
   end
-  
+
 end

--- a/spec/models/service_ticket_spec.rb
+++ b/spec/models/service_ticket_spec.rb
@@ -7,48 +7,48 @@ describe Cassy::ServiceTicket do
     @ticket_granting_ticket = Cassy::TicketGrantingTicket.create(:ticket => "TGT-12345678900987654321", :created_on => Time.now, :username => "1", :client_hostname => "http://sss.something.com", :extra_attributes => {})
     @service_ticket = Cassy::ServiceTicket.create!(:ticket => "ST-12345678901234567890", :consumed => false, :client_hostname => "http://sso.something.com", :granted_by_tgt => @ticket_granting_ticket, :service => "http://members.something.com", :username => "1")
   end
-  
+
   it "should validate" do
-    Cassy::ServiceTicket.validate("http://members.something.com","ST-12345678901234567890").should == [@service_ticket, "Ticket 'ST-12345678901234567890' for 'http://members.something.com' for user '1' successfully validted."]    
+    Cassy::ServiceTicket.validate_ticket("http://members.something.com","ST-12345678901234567890").should == [@service_ticket, "Ticket 'ST-12345678901234567890' for 'http://members.something.com' for user '1' successfully validted."]
   end
-  
+
   it "should not validate if the ticket has already been consumed" do
     @service_ticket.consume!
-    Cassy::ServiceTicket.validate("http://members.something.com","ST-12345678901234567890").should == [nil, "Ticket ST-12345678901234567890 has already been consumed."]
+    Cassy::ServiceTicket.validate_ticket("http://members.something.com","ST-12345678901234567890").should == [nil, "Ticket ST-12345678901234567890 has already been consumed."]
   end
 
   it "should not validate if the ticket is too old" do
     @service_ticket.created_on = Time.now-7201
     @service_ticket.save!
-    Cassy::ServiceTicket.validate("http://members.something.com", "ST-12345678901234567890").should == [nil, "Ticket ST-12345678901234567890 has expired. Please try again."]
+    Cassy::ServiceTicket.validate_ticket("http://members.something.com", "ST-12345678901234567890").should == [nil, "Ticket ST-12345678901234567890 has expired. Please try again."]
   end
-  
+
   it "should not validate if the ticket is invalid" do
-    Cassy::ServiceTicket.validate("http://members.something.com", "ST-09876543210987654321").should == [nil, "Ticket 'ST-09876543210987654321' not recognized."]
+    Cassy::ServiceTicket.validate_ticket("http://members.something.com", "ST-09876543210987654321").should == [nil, "Ticket 'ST-09876543210987654321' not recognized."]
   end
-  
+
   describe "#send_logout_notification" do
-    
+
     it "should send valid single sign out XML to the service URL" do
-      
+
       service_stub = stub_request(:post, 'http://example.com')
-      
+
       st = Cassy::ServiceTicket.new(
         :ticket => 'ST-0123456789ABCDEFGHIJKLMNOPQRS',
         :service => 'http://example.com',
         :consumed => false,
         :client_hostname => "http://sso.something.com"
       )
-      
+
       st.send_logout_notification
 
       a_request(:post, 'example.com').with{ |req|
         xml = CGI.parse(req.body)['logoutRequest'].first
         Nokogiri::XML(xml).at_xpath('//samlp:SessionIndex').text.strip == st.ticket
       }.should have_been_made
-      
+
     end
-    
+
   end
-  
+
 end

--- a/spec/models/ticket_granting_ticket_spec.rb
+++ b/spec/models/ticket_granting_ticket_spec.rb
@@ -6,29 +6,29 @@ describe Cassy::TicketGrantingTicket do
     Cassy::TicketGrantingTicket.delete_all
     @ticket_granting_ticket = Cassy::TicketGrantingTicket.create(:ticket => "TGT-12345678900987654321", :created_on => Time.now, :username => "1", :client_hostname => "http://sss.something.com", :extra_attributes => {})
   end
-  
+
   it "should validate" do
-    Cassy::TicketGrantingTicket.validate("TGT-12345678900987654321").should == [@ticket_granting_ticket, "Ticket granting ticket 'TGT-12345678900987654321' for user '1' successfully validated."]    
+    Cassy::TicketGrantingTicket.validate_ticket("TGT-12345678900987654321").should == [@ticket_granting_ticket, "Ticket granting ticket 'TGT-12345678900987654321' for user '1' successfully validated."]
   end
 
   it "should not validate if the ticket is too old" do
     @ticket_granting_ticket.created_on = Time.now-7201
     @ticket_granting_ticket.save!
-    Cassy::TicketGrantingTicket.validate("TGT-12345678900987654321").should == [nil, "Ticket TGT-12345678901234567890 has expired. Please log in again."]
+    Cassy::TicketGrantingTicket.validate_ticket("TGT-12345678900987654321").should == [nil, "Ticket TGT-12345678901234567890 has expired. Please log in again."]
   end
-  
+
   it "should not validate if the ticket is invalid" do
-    Cassy::TicketGrantingTicket.validate("TGT-09876543210987654321").should == [nil, "Ticket 'TGT-09876543210987654321' not recognized."]
+    Cassy::TicketGrantingTicket.validate_ticket("TGT-09876543210987654321").should == [nil, "Ticket 'TGT-09876543210987654321' not recognized."]
   end
-  
+
   context "single sign out" do
-  
+
     before do
-      @service_ticket = Cassy::ServiceTicket.create!(:granted_by_tgt_id => @ticket_granting_ticket.id, 
+      @service_ticket = Cassy::ServiceTicket.create!(:granted_by_tgt_id => @ticket_granting_ticket.id,
         :service => "www.another.com", :ticket => "ST-1362563155rFE13971A3BCC04C6B5", :client_hostname => "another", :username => "1")
       Cassy.config[:enable_single_sign_out] = true
     end
-    
+
     it "sends a logout notification for all granted service tickets before being destroyed" do
       Cassy::ServiceTicket.any_instance.should_receive(:send_logout_notification)
       @ticket_granting_ticket.destroy_and_logout_all_service_tickets
@@ -36,55 +36,55 @@ describe Cassy::TicketGrantingTicket do
         Cassy::TicketGrantingTicket.find(@ticket_granting_ticket.id)
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
-    
+
     it "raises an error if single sign out is not enabled" do
       Cassy.config[:enable_single_sign_out] = false
       expect {
         @ticket_granting_ticket.destroy_and_logout_all_service_tickets
       }.to raise_error("Single Sign Out is not enabled for Cassy. If you want to enable it, add 'enable_single_sign_out: true' to the Cassy config file.")
     end
-    
+
     context "logging in with a second session and 'no_concurrent_sessions' enabled" do
-      
+
       before do
         Cassy.config[:no_concurrent_sessions] = true
         @ticket_granting_ticket = Cassy::TicketGrantingTicket.create!(:ticket => "TGT-981276451234567890", :username => "1", :client_hostname => "127.0.0.1")
       end
-      
+
       it "returns any ticket_granting_tickets that were created after the one stored in the session" do
         @second_ticket_granting_ticket = Cassy::TicketGrantingTicket.generate("1", nil, "127.0.0.1")
         @ticket_granting_ticket.not_the_latest_for_this_user?.should be_true
       end
-      
+
       it "should send a request to terminate the old session" do
         Cassy::TicketGrantingTicket.any_instance.should_receive(:destroy_and_logout_all_service_tickets)
         @second_ticket_granting_ticket = Cassy::TicketGrantingTicket.generate("1", nil, "127.0.0.1")
       end
-      
+
     end
-    
+
     context "logging in with a second session and 'no_concurrent_sessions' disabled" do
-      
+
       before do
         Cassy::TicketGrantingTicket.delete_all
         Cassy.config[:no_concurrent_sessions] = nil
         @ticket_granting_ticket = Cassy::TicketGrantingTicket.create!(:ticket => "TGT-981276451234567890", :username => "1", :client_hostname => "127.0.0.1")
       end
-      
+
       it "should have two sessions" do
         Cassy::TicketGrantingTicket.any_instance.should_not_receive(:destroy_and_logout_all_service_tickets)
         @second_ticket_granting_ticket = Cassy::TicketGrantingTicket.generate("1", nil, "127.0.0.1")
         Cassy::TicketGrantingTicket.where(:username => "1").count.should == 2
       end
-      
+
     end
-    
+
     it "returns the previous ticket for the username" do
       Cassy.config[:enable_single_sign_out] = true # otherwise they will be deleted
       @second_ticket_granting_ticket = Cassy::TicketGrantingTicket.generate("1", nil, "127.0.0.1")
       @second_ticket_granting_ticket.previous_ticket.should == @ticket_granting_ticket
     end
-  
+
   end
-  
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'webmock/rspec'
 ENV["RAILS_ENV"] = "test"
 ENV["RUBYCAS_CONFIG_FILE"] = File.expand_path("default_config.yml", File.dirname(__FILE__))
 
-require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+require File.expand_path("../dummy/config/application.rb",  __FILE__)
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
When trying to write a custom authenticator that needed access to the Rack request object, I discovered that the `credentials` hash didn't include the request, despite having a `:request` key.  This seems to be because the `@env` instance variable doesn't exist in the controller (I believe it may have once existed in past versions of Rails).

Since none of the authenticators that ship with Cassy actually reference the `:request` key, I think it should be safe to simply make it pass the Rack request object (which will still grant access to the Rack environment by calling `credentials[:request].env`).  However, this change may break some people's custom authenticators if they are running a sufficiently old version of Rails that `@env` does exist; if they are, they would need to use `credentials[:request].env` rather than `credentials[:request]`.
