### PR TITLE
Add support for multiple sessions with no concurrent sessions enabled, if they are separate device types. 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Put this line in your project's `Gemfile`:
 Create a new initializer (probably called `config/initializers/cassy.rb`) and point cassy at the correct configuration file of your application:
 
     Cassy::Engine.config.config_file = Rails.root + "config/cassy.yml"
-    
+
 Create this configuration file at `config/cassy.yml`. Fill it with these values:
 
     # Times are in seconds.
@@ -31,7 +31,7 @@ Next, you will need to tell Cassy to load its routes in your application which y
 
     Rails.application.routes.draw do
       cassy
-      
+
       # your routes go here
     end
 
@@ -51,11 +51,12 @@ These configuration options are detailed here for your convenience. For specific
 * `username_field`: Defines the field on the users table which is used for the lookup for the username. Defaults to " username".
 * `username_label`: Allows for the "Username" label on the sign in page to be given a different value. Helpful if you want to call it "Email" or "User Name" instead.
 * `client_app_user_field`: Defines the field name for the username on the *client* application side.
-* `service_list`: List of services that use this server to authenticate, separated by environment. 
+* `service_list`: List of services that use this server to authenticate, separated by environment.
 * `default_redirect_url`: If the requested service isn't in the service_list (or is blank) then tickets will be generated for the valid services then the user will be redirected to here. Needs to be specified per environment as per the sample below. The default_redirect_url needs to be on the same domain as (at least) one of the urls on the service_list.
 * `loosely_match_services`: If this is set to true, a request for the service http://www.something.com/something_else can be matched to the ticket for http://www.something.com.
 * `enable_single_sign_out`: If this is set to true, calling send_logout_notification on a service ticket will send a request to the service telling it to clear the associated users session. Calling destroy_and_logout_all_service_tickets on a ticket granting ticket will send a session-terminating request to each service before destroying itself.
 * `no_concurrent_sessions`: (requires enable_single_sign_out to be true) If this is true, when someone logs in, a session-terminating request is sent to each service for any old service tickets related to the current user.
+* `concurrent_session_types`:  If no_concurrent_sessions is true, concurrent_session_types can be specified so that a user can have concurrent sessions on different device types.  If enabled, override `session_type` in `SessionsController` to return the session_type (any string).  
 
 
 A sample `cassy.yml` file:
@@ -79,6 +80,8 @@ A sample `cassy.yml` file:
     loosely_match_services: true
     authenticator:
       class: Cassy::Authenticators::Devise
+    no_concurrent_sessions: true
+    concurrent_session_types: [:mobile, :desktop]
     extra_attributes:
       - user_id
       - user_username
@@ -98,4 +101,3 @@ By doing this, it will point at the `SessionsController` rather than the default
         # custom behaviour goes here
         super
       end
-        

--- a/app/api/cassy/api.rb
+++ b/app/api/cassy/api.rb
@@ -1,0 +1,10 @@
+require "grape"
+module Cassy
+  class API < Grape::API
+    helpers Cassy::CAS
+
+    format :json
+
+    mount Cassy::API::Resource::TicketGrantingTickets
+  end
+end

--- a/app/api/cassy/api/entity/service_ticket.rb
+++ b/app/api/cassy/api/entity/service_ticket.rb
@@ -1,0 +1,6 @@
+require 'grape-entity'
+module Cassy
+  class API::Entity::ServiceTicket < Grape::Entity
+    expose :ticket
+  end
+end

--- a/app/api/cassy/api/entity/ticket_granting_ticket.rb
+++ b/app/api/cassy/api/entity/ticket_granting_ticket.rb
@@ -1,0 +1,6 @@
+require 'grape-entity'
+module Cassy
+  class API::Entity::TicketGrantingTicket < Grape::Entity
+    expose :ticket
+  end
+end

--- a/app/api/cassy/api/resource/ticket_granting_tickets.rb
+++ b/app/api/cassy/api/resource/ticket_granting_tickets.rb
@@ -1,0 +1,36 @@
+require "grape"
+module Cassy
+  class API::Resource::TicketGrantingTickets < Grape::API
+    resource :tickets do
+      desc "Create a ticket_granting_ticket"
+      post do
+        if valid_credentials?
+          @hostname = env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_HOST'] || env['REMOTE_ADDR']
+          @ticket = Cassy::TicketGrantingTicket.generate("#{ticket_username}-api", @extra_attributes, @hostname)
+          Rails.logger.debug "Created auth token ticket '#{@ticket.ticket}'"
+          present @ticket, with: Cassy::API::Entity::TicketGrantingTicket
+        else
+          error! "Invalid Credentials", 400
+        end
+      end
+
+      desc "Request a service_ticket"
+      post ":id" do
+        tgt, error = TicketGrantingTicket.validate(params[:id])
+        if tgt
+          @hostname = env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_HOST'] || env['REMOTE_ADDR']
+          @ticket = ServiceTicket.generate(params[:service], tgt.username, tgt, @hostname)
+          present @ticket, with: Cassy::API::Entity::ServiceTicket
+        else
+          error! "Invalid ticket or service", 400
+        end
+      end
+
+      delete ":id" do
+        tgt, error = TicketGrantingTicket.validate(params[:id])
+        tgt.destroy_and_logout_all_service_tickets if tgt
+        return ""
+      end
+    end
+  end
+end

--- a/app/controllers/cassy/sessions_controller.rb
+++ b/app/controllers/cassy/sessions_controller.rb
@@ -19,7 +19,7 @@ module Cassy
       end
 
       if @service
-        if @ticketed_user && cas_login
+        if @ticketed_user && cas_login(session_type)
           redirect_to @service_with_ticket
         elsif @existing_ticket_for_service
           redirect_to logout_url
@@ -166,7 +166,7 @@ module Cassy
     def incorrect_credentials!
       @lt = generate_login_ticket.ticket
       flash.now[:error] = "Incorrect username or password."
-      render :new, :status => 401
+      redirect_to new_user_session_path, status: 401
     end
 
   end

--- a/app/controllers/cassy/sessions_controller.rb
+++ b/app/controllers/cassy/sessions_controller.rb
@@ -5,7 +5,7 @@ module Cassy
 
     def new
       detect_ticketing_service(params[:service])
-      
+
       @renew = params['renew']
       @gateway = params['gateway'] == 'true' || params['gateway'] == '1'
       @hostname = env['HTTP_X_FORWARDED_FOR'] || env['REMOTE_HOST'] || env['REMOTE_ADDR']
@@ -17,7 +17,7 @@ module Cassy
       if params['redirection_loop_intercepted']
         flash.now[:error] = "The client and server are unable to negotiate authentication. Please try logging in again later."
       end
-      
+
       if @service
         if @ticketed_user && cas_login
           redirect_to @service_with_ticket
@@ -36,7 +36,7 @@ module Cassy
 
       @lt = generate_login_ticket.ticket
     end
-    
+
     def create
       @lt = generate_login_ticket.ticket # in case the login isn't successful, another ticket needs to be generated for the next attempt at login
       detect_ticketing_service(params[:service])
@@ -49,18 +49,18 @@ module Cassy
       end
 
       logger.debug("Logging in with username: #{@username}, lt: #{@lt}, service: #{@service}, auth: #{settings[:auth].inspect}")
-      if cas_login
+      if cas_login(session_type)
         if @service_with_ticket
           redirect_to after_sign_in_path_for(@service_with_ticket)
         else
           flash.now[:notice] = "You have successfully logged in."
           render :new
-        end        
+        end
       else
         incorrect_credentials!
       end
     end
-    
+
     def destroy
       # The behaviour here is somewhat non-standard. Rather than showing just a blank
       # "logout" page, we take the user back to the login page with a "you have been logged out"
@@ -74,7 +74,7 @@ module Cassy
       tgt = Cassy::TicketGrantingTicket.find_by_ticket(request.cookies['tgt'])
 
       response.delete_cookie 'tgt'
-      
+
       if tgt
         Cassy::TicketGrantingTicket.transaction do
           pgts = Cassy::ProxyGrantingTicket.
@@ -92,7 +92,7 @@ module Cassy
           tgt.destroy
         end
       end
-       
+
       flash[:notice] = "You have successfully logged out."
       @lt = generate_login_ticket
 
@@ -102,10 +102,10 @@ module Cassy
         redirect_to :action => :new, :service => @service
       end
     end
-    
+
     def service_validate
       # takes a params[:service] and a params[:ticket] and validates them
-      
+
       # required
       @service = clean_service_url(params['service'])
       @ticket = params['ticket']
@@ -124,7 +124,7 @@ module Cassy
       end
       render :proxy_validate, :layout => false, :status => @service_ticket ? 200 : 422
     end
-    
+
     def proxy_validate
       # required
       @service = clean_service_url(params['service'])
@@ -153,11 +153,16 @@ module Cassy
       end
 
       render :proxy_validate, :layout => false, :status => @service_ticket ? 200 : 422
-      
+
     end
-    
+
     private
-    
+
+    def session_type
+      raise NotImplementedError if Cassy.config[:concurrent_session_types]
+      nil
+    end
+
     def incorrect_credentials!
       @lt = generate_login_ticket.ticket
       flash.now[:error] = "Incorrect username or password."

--- a/app/controllers/cassy/sessions_controller.rb
+++ b/app/controllers/cassy/sessions_controller.rb
@@ -77,9 +77,9 @@ module Cassy
       
       if tgt
         Cassy::TicketGrantingTicket.transaction do
-          pgts = Cassy::ProxyGrantingTicket.find(:all,
-            :conditions => [ActiveRecord::Base.connection.quote_table_name(Cassy::ServiceTicket.table_name)+".username = ?", tgt.username],
-            :include => :service_ticket)
+          pgts = Cassy::ProxyGrantingTicket.
+            where(ActiveRecord::Base.connection.quote_table_name(Cassy::ServiceTicket.table_name) + ".username" => tgt.username).
+            includes(:service_ticket)
           pgts.each do |pgt|
             pgt.destroy
           end

--- a/cassy.gemspec
+++ b/cassy.gemspec
@@ -10,6 +10,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'crypt-isaac', '>= 1.0.0'
   s.add_dependency 'rails', '>= 3.0.9'
+  s.add_dependency 'grape', '~> 0.14'
+  s.add_dependency 'grape-entity', '~> 0.5'
+
 
   s.add_development_dependency 'rspec-rails', '~> 2.7.0'
   s.add_development_dependency 'capybara', '~> 1.0'

--- a/cassy.gemspec
+++ b/cassy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "README.markdown"]
   s.version = "2.0.3"
 
-  s.add_dependency 'crypt-isaac'
+  s.add_dependency 'crypt-isaac', '>= 1.0.0'
   s.add_dependency 'rails', '>= 3.0.9'
 
   s.add_development_dependency 'rspec-rails', '~> 2.7.0'

--- a/lib/cassy/authenticators/devise.rb
+++ b/lib/cassy/authenticators/devise.rb
@@ -12,7 +12,8 @@ module Cassy
         return if ticket.nil?
         key  = Cassy.config[:client_app_user_field] || Cassy.config[:username_field] || "email"
         method = "find_by_#{key}"
-        User.send(method, ticket.username)
+        username = Cassy.config[:concurrent_session_types] ? Cassy.config[:concurrent_session_types].each{ |cst| break ticket.username.rpartition("-#{cst}").first if ticket.username.match("-#{cst}") } : ticket.username
+        User.send(method, username)
       end
 
       def self.validate(credentials)

--- a/lib/cassy/cas.rb
+++ b/lib/cassy/cas.rb
@@ -8,7 +8,7 @@ require 'cassy/utils'
 # the Cassy::Controllers module.
 module Cassy
   module CAS
-    
+
     def settings
       Cassy.config
     end
@@ -66,7 +66,7 @@ module Cassy
       https.start do |conn|
         path = uri.path.empty? ? '/' : uri.path
         path += '?' + uri.query unless (uri.query.nil? || uri.query.empty?)
-      
+
         pgt = ProxyGrantingTicket.new
         pgt.ticket = "PGT-" + Cassy::Utils.random_string(60)
         pgt.iou = "PGTIOU-" + Cassy::Utils.random_string(57)
@@ -81,7 +81,7 @@ module Cassy
         response = conn.request_get(path)
         # TODO: follow redirects... 2.5.4 says that redirects MAY be followed
         # NOTE: The following response codes are valid according to the JA-SIG implementation even without following redirects
-      
+
         if %w(200 202 301 302 304).include?(response.code)
           # 3.4 (proxy-granting ticket IOU)
           pgt.save!
@@ -143,7 +143,7 @@ module Cassy
     module_function :clean_service_url
 
     def base_service_url(full_service_url)
-      # strips a url back to the domain part only 
+      # strips a url back to the domain part only
       # so that a service ticket can work for all urls on a given domain
       # eg http://www.something.com/something_else
       # is stripped back to
@@ -154,13 +154,13 @@ module Cassy
       match && match[0]
     end
     module_function :base_service_url
-    
+
     def detect_ticketing_service(service)
       # try to find the service in the valid_services list
       # if loosely_matched_services is true, try to match the base url of the service to one in the valid_services list
       # if still no luck, check if there is a default_redirect_url that we can use
       @service||= service
-      @ticketing_service||= valid_services.detect{|s| s == @service } || 
+      @ticketing_service||= valid_services.detect{|s| s == @service } ||
         (settings[:loosely_match_services] == true && valid_services.detect{|s| base_service_url(s) == base_service_url(@service)})
       if !@ticketing_service && settings[:default_redirect_url]
         @default_redirect_url||= settings[:default_redirect_url][Rails.env]
@@ -171,14 +171,17 @@ module Cassy
       @lt||= params['lt']
     end
     module_function :detect_ticketing_service
-    
-    def cas_login
+
+    def cas_login(session_type = nil)
       if valid_credentials?
-        @tgt||= Cassy::TicketGrantingTicket.generate(ticket_username, @extra_attributes, @hostname)
+        username = ticket_username
+        username = "#{username}-#{session_type}" if Cassy.config[:concurrent_session_types]
+
+        @tgt||= Cassy::TicketGrantingTicket.generate(username, @extra_attributes, @hostname)
         @existing_ticket_for_service = @tgt.granted_service_tickets.where(:service => @service).where("created_on > ?", Time.now - Cassy.config[:maximum_session_lifetime]).where("consumed IS NOT NULL").first
         response.set_cookie('tgt', @tgt.to_s)
         if @ticketing_service
-          find_or_generate_service_tickets(ticket_username, @tgt, @hostname)
+          find_or_generate_service_tickets(username, @tgt, @hostname)
           @st = @service_tickets[@ticketing_service]
           @service_with_ticket = @service && @st ? service_uri_with_ticket(@service, @st) : @default_redirect_url
         end
@@ -191,7 +194,7 @@ module Cassy
       end
     end
     module_function :cas_login
-    
+
     # Initializes authenticator, returns true / false depending on if user credentials are accurate
     def valid_credentials?
       detect_ticketing_service(params[:service])
@@ -213,7 +216,7 @@ module Cassy
       return valid
     end
     module_function :valid_credentials?
-    
+
     protected
 
     def ticket_username
@@ -223,7 +226,7 @@ module Cassy
       @cas_client_username = user.send(settings["client_app_user_field"]) if settings["client_app_user_field"].present? && !!user
       @cas_client_username || @username
     end
-    
+
     def ticketed_user(ticket)
       # Find the SSO's instance of the user
       @ticketed_user ||= authenticator.find_user_from_ticket(ticket) unless !ticket

--- a/lib/cassy/routes.rb
+++ b/lib/cassy/routes.rb
@@ -4,11 +4,12 @@ module ActionDispatch::Routing
       options[:controllers] ||= HashWithIndifferentAccess.new
       options[:controllers][:sessions] ||= "cassy/sessions"
       scope(:path => "cas") do
+        mount Cassy::API => '/api'
         get 'login', :to => "#{options[:controllers][:sessions]}#new"
         post 'login', :to => "#{options[:controllers][:sessions]}#create"
-        
+
         get 'logout', :to => "#{options[:controllers][:sessions]}#destroy"
-        
+
         get 'serviceValidate', :to => "#{options[:controllers][:sessions]}#service_validate"
         get 'proxyValidate',   :to => "#{options[:controllers][:sessions]}#proxy_validate"
       end

--- a/lib/cassy/utils.rb
+++ b/lib/cassy/utils.rb
@@ -1,5 +1,4 @@
-require 'crypt-isaac'
-
+require 'crypt/isaac'
 # Misc utility function used throughout by the RubyCAS-Server.
 module Cassy
   module Utils


### PR DESCRIPTION
Configuring this option allows a user to have one session per allowed device type. 

For example, if you set concurrent_session_types = [:mobile, :desktop], then override session_type to return one of those values, the user can have one 'mobile' session, and one 'desktop' session.  
