### PR TITLE
Cassy cleanup

### DIFF
--- a/lib/cassy/version.rb
+++ b/lib/cassy/version.rb
@@ -1,3 +1,3 @@
 module Cassy
-  VERSION = "2.1"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
Splits up some of cas_login and validate_user

This cleanup is not used yet internally by cassy, but allows
other apps to hook into the login process more.